### PR TITLE
Use window size information to decide tiling direction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ async fn main() {
     }
 
     //If we error out attempting to subscribe to GWM, kill the process.
-    if let Err(e) = socket.send(Message::Text("subscribe -e window_managed".into())) {
+    if let Err(e) = socket.send(Message::Text("subscribe -e focus_changed".into())) {
         eprintln!("\nERR: Could not parse raw message data from initial GWM subscription! Raw error:\n{e}\n");
     } else {
         loop {
@@ -102,9 +102,7 @@ async fn main() {
                 }
             };
 
-            if let Some((x, y)) = get_window_height_width(&json_msg["data"]["focusedContainer"])
-                .or_else(|| get_window_height_width(&json_msg["data"]["managedWindow"]))
-            {
+            if let Some((x, y)) = get_window_height_width(&json_msg["data"]["focusedContainer"]) {
                 size_tile(&mut socket, x, y).unwrap();
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,15 +47,16 @@ async fn main() {
 
     //Create menu label to show what it is.
     match tray.add_label("GAT - GlazeWM Alternating Tiler") {
-        Ok(_) => {}
+        Ok(()) => {}
         Err(e) => eprintln!("\nERR: Could not add label to System Tray!\nRaw Error: {e}\n"),
     }
 
     //Create menu item for exiting program.
-    match tray.add_menu_item("Quit GAT", || {
+    let menu_item_function = || {
         std::process::exit(0);
-    }) {
-        Ok(_) => {}
+    };
+    match tray.add_menu_item("Quit GAT", menu_item_function) {
+        Ok(()) => {}
         Err(e) => {
             eprintln!(
                 "\nERR: Failed to add menu item! How did this even compile?\nRaw Error: {e}\n"
@@ -78,8 +79,8 @@ async fn main() {
     //Successful connection, print debug info.
     println!("Connected to GWM\nResCode - {}", response.status());
     println!("Response Headers:\n");
-    for (ref header, _value) in response.headers() {
-        println!("* {}", header);
+    for (header, _value) in response.headers() {
+        println!("* {}", &header);
     }
 
     //If we error out attempting to subscribe to GWM, kill the process.
@@ -102,9 +103,9 @@ async fn main() {
             };
 
             if let Some((x, y)) = get_window_height_width(&json_msg["data"]["focusedContainer"])
-                .or(get_window_height_width(&json_msg["data"]["managedWindow"]))
+                .or_else(|| get_window_height_width(&json_msg["data"]["managedWindow"]))
             {
-                size_tile(&mut socket, x, y).unwrap()
+                size_tile(&mut socket, x, y).unwrap();
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 #![windows_subsystem = "windows"]
 
+use std::net::TcpStream;
+
 use serde_json::Value;
-use tray_item::{ IconSource, TrayItem };
-use tungstenite::{ connect, Message };
+use tray_item::{IconSource, TrayItem};
+use tungstenite::{connect, stream::MaybeTlsStream, Message, WebSocket};
 use url::Url;
 
 // Retaining the unsafe function in case it proves to be necessary later, will
@@ -45,15 +47,19 @@ async fn main() {
 
     //Create menu label to show what it is.
     match tray.add_label("GAT - GlazeWM Alternating Tiler") {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(e) => eprintln!("\nERR: Could not add label to System Tray!\nRaw Error: {e}\n"),
     }
 
     //Create menu item for exiting program.
-    match tray.add_menu_item("Quit GAT", || { std::process::exit(0); }) {
-        Ok(_) => {},
+    match tray.add_menu_item("Quit GAT", || {
+        std::process::exit(0);
+    }) {
+        Ok(_) => {}
         Err(e) => {
-            eprintln!("\nERR: Failed to add menu item! How did this even compile?\nRaw Error: {e}\n");
+            eprintln!(
+                "\nERR: Failed to add menu item! How did this even compile?\nRaw Error: {e}\n"
+            );
             panic!("\nMOR: Cannot continue runtime, please double-check your computer configuration!\n");
         }
     }
@@ -86,20 +92,42 @@ async fn main() {
                     .read()
                     .expect("ERR: Could not read message!\n")
                     .to_text()
-                    .unwrap_or_default()
+                    .unwrap_or_default(),
             ) {
                 Ok(v) => v,
                 Err(e) => {
                     eprintln!("\nERR: GWM WS MSG could not be parsed to Value! Raw error:\n{e}\n");
-                    continue
+                    continue;
                 }
             };
 
-            if let Some(f) = json_msg["data"]["managedWindow"]["sizePercentage"].as_f64() {
-                if f <= 0.5 {
-                    socket.send(Message::Text(String::from("command \"tiling direction toggle\""))).unwrap();
-                }
+            if let Some((x, y)) = get_window_height_width(&json_msg["data"]["focusedContainer"])
+                .or(get_window_height_width(&json_msg["data"]["managedWindow"]))
+            {
+                size_tile(&mut socket, x, y).unwrap()
             }
         }
     }
+}
+
+fn size_tile(
+    socket: &mut WebSocket<MaybeTlsStream<TcpStream>>,
+    x: f64,
+    y: f64,
+) -> Result<(), tungstenite::Error> {
+    if x < y {
+        socket.send(Message::Text(String::from(
+            "command \"tiling direction vertical\"",
+        )))
+    } else {
+        socket.send(Message::Text(String::from(
+            "command \"tiling direction horizontal\"",
+        )))
+    }
+}
+
+fn get_window_height_width(v: &Value) -> Option<(f64, f64)> {
+    v["width"]
+        .as_f64()
+        .and_then(|x| v["height"].as_f64().map(|y| (x, y)))
 }


### PR DESCRIPTION
This PR changes the behavior of the program to make it so that, instead of blindly toggling the tiling direction, it uses the size of the currently focused window to more smartly decide what the direction should be.

If the window is wider than it is tall, then the tiling direction will be horizontal, so that the next window will split it vertically in half. Otherwise, the tiling direction will be vertical. This means that space is always distributed most efficiently between a newly opened window and a previously existing one.

I tried to make it so that it also sets tiling direction when the program starts, but the `windows` request does not indicate which window is currently focused (possibly unintended behavior on GlazeWM's part? Not that it matters with v3 being around the corner)